### PR TITLE
Condition情報の登録機能、ユーザー毎のCondition情報表示、全てのユーザー＆Condition情報表示API作成

### DIFF
--- a/app/Http/Controllers/ConditionController.php
+++ b/app/Http/Controllers/ConditionController.php
@@ -4,16 +4,67 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Conditiondata;
+use App\Condition;
+use App\User;
+use App\Http\Requests\ConditionRequest;
+use Illuminate\Support\Facades\Auth;
+
 
 class ConditionController extends Controller
 {
+    // マイページ
     public function index(){
 
-        return view('conditions.mypage');
+        return view('conditions.index');
     }
 
+    // Condition情報入力フォーム
     public function create() {
         $conditiondatas = Conditiondata::all();
         return view('conditions.create', compact('conditiondatas'));
     }
+
+    // Condition情報保存
+    public function store(ConditionRequest $request, Condition $condition) {
+        $condition->start = $request->start;
+        $condition->diagnosis = $request->diagnosis;
+        $condition->hospital = $request->hospital;
+        $condition->others = $request->others;
+        $condition->comment = $request->comment;
+        $condition->icon = $request->icon;
+        $condition->conditiondata_id = $request->conditiondata_id;
+        $condition->user_id = $request->user_id;
+        $condition->save();
+        return redirect()->route('conditions.index');
+    }
+
+    // 全てのユーザー情報、Condition情報抽出API
+    public function  allinfo() {
+        $users = User::all();
+        $conditions = Condition::all();
+
+        return response()->json([
+            'users' => $users->toArray(),
+            'conditions' => $conditions->toArray(),
+        ], 400);
+    }
+
+
+    // ログインユーザーのCondition情報抽出API
+    public function show($id) {
+        $condition = auth()->user()->conditions()->find($id);
+
+        if(!$condition) {
+            return response()->json([
+                'success' => false,
+                'data' => '該当のデータは見つかりませんでした'
+            ], 400);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => $condition->toArray(),
+        ], 400);
+    }
+
 }

--- a/app/Http/Controllers/ConditionController.php
+++ b/app/Http/Controllers/ConditionController.php
@@ -41,10 +41,13 @@ class ConditionController extends Controller
     // 全てのユーザー情報、Condition情報抽出API
     public function  allinfo() {
         $users = User::all();
-        $conditions = Condition::all();
+        // $conditions = Condition::all();
+
+        $conditions = Condition::select()
+       ->join('users','users.id','=','conditions.user_id')
+       ->get(); 
 
         return response()->json([
-            'users' => $users->toArray(),
             'conditions' => $conditions->toArray(),
         ], 400);
     }

--- a/app/Http/Requests/ConditionRequest.php
+++ b/app/Http/Requests/ConditionRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+
+class ConditionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'start' => 'required',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'start' => 'いつから感じたか',
+            'condition_id' => '病名',
+        ];
+    }
+}

--- a/database/migrations/2021_05_02_043355_create_conditions_table.php
+++ b/database/migrations/2021_05_02_043355_create_conditions_table.php
@@ -20,11 +20,11 @@ class CreateConditionsTable extends Migration
         Schema::create('conditions', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->date('start');
-            $table->date('diagnosis');
+            $table->date('diagnosis')->nullable();
             $table->string('hospital');
             $table->text('others')->nullable();
-            $table->text('comment');
-            $table->text('feelings');
+            $table->text('comment')->nullable();
+            $table->text('icon')->nullable();
             $table->bigInteger('conditiondata_id');
             $table->unsignedInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users');

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -40,7 +40,7 @@
                 </select>
                 <div id="birthday" class="md-form md-outline input-with-post-icon">
                     <input type="date" id="birthday" name="birthday" class="form-control">
-                    <label for="example">生年月日</label>
+                    <label for="birthday">生年月日</label>
                 </div>
                 <div class="custom-file mb-3">
                   <input type="file" class="custom-file-input" id="icon" name="icon">

--- a/resources/views/conditions/create.blade.php
+++ b/resources/views/conditions/create.blade.php
@@ -14,41 +14,49 @@
             @include('error_card_list') 
 
             <div class="card-text">
-              <form method="POST" action="{{ route('register') }}">
+              <form method="POST" action="{{ route('conditions.store') }}">
                 @csrf
                 <div class="md-form">
-                  <select class="custom-select mb-3" id="condition_name" name="condition_name">
+                  <select class="custom-select mb-3" id="conditiondata_id" name="conditiondata_id">
+                  <option selected>病名を選ぶ</option>
                     @foreach($conditiondatas as $data)
                         <option value="{{ $data->id }}">{{ $data->name }}</option>
                     @endforeach
+                  </select>
                 </div>
-                </select>
+                <div id="start" class="md-form md-outline input-with-post-icon">
+                    <input type="date" id="start" name="start" class="form-control">
+                    <label for="start" class="mt-1">いつから感じたか</label>
+                </div>
+                <div id="diagnosis" class="md-form md-outline input-with-post-icon">
+                    <input type="date" id="diagnosis" name="diagnosis" class="form-control">
+                    <label for="diagnosis" class="mt-1">いつ診断されたか</label>
+                </div>
                 <div class="md-form">
-                  <label for="email">メールアドレス</label>
-                  <input class="form-control" type="text" id="email" name="email" required value="{{ old('email') }}" >
+                  <select class="custom-select mb-1" id="hospital" name="hospital">
+                  <option selected>今病院に通っているか</option>
+                    <option value="通っている">通っている</option>
+                    <option value="通っていない">通っていない</option>
+                    <option value="通っていないが病気だと感じている">通っていないが病気だと感じている</option>
+                    <option value="その他">その他</option>
+                  </select>
                 </div>
-                <div class="md-form">
-                  <label for="password">パスワード</label>
-                  <input class="form-control" type="password" id="password" name="password" required>
+                <div class="mb-3">
+                  <input type="text" class="form-control" id="others"  name="others" placeholder="その他を選んだ場合はこちらに記入">
                 </div>
-                <div class="md-form">
-                  <label for="password_confirmation">パスワード(確認)</label>
-                  <input class="form-control" type="password" id="password_confirmation" name="password_confirmation" required>
+                <div class="form-group">
+                  <div class="checkbox-inline" style="width:40%;">
+                    <label class="checkbox" for="icon">
+                      <input type="checkbox" data-toggle="checkbox" value="治療完了" id="icon" name="icon"> 治療完了（not 必須事項）
+                    </label>
+                  </div>
                 </div>
-                <div id="birthday" class="md-form md-outline input-with-post-icon">
-                    <input type="date" id="birthday" name="birthday" class="form-control">
-                    <label for="example">生年月日</label>
+                <div class="mb-3">
+                  <textarea class="form-control" id="comment" name="comment" rows="3" placeholder="具体的な症状等"></textarea>
                 </div>
-                <div class="custom-file mb-3">
-                  <input type="file" class="custom-file-input" id="icon" name="icon">
-                  <label class="custom-file-label" for="icon">プロフィール画像</label>
-                </div>
-                <button class="btn btn-block mean-fruit-gradient mt-2 mb-2" type="submit">ユーザー登録</button>
+                <input type="hidden" id="user_id" name="user_id" required value="{{ Auth::user()->id }}">
+                <button class="btn btn-block mean-fruit-gradient mt-2 mb-2" type="submit">Condition登録</button>
               </form>
-              <div class="mt-0">
-                <a href="{{ route('login') }}" class="card-text">ログインはこちら</a>
-              </div>
-              
             </div>
           </div>
         </div>

--- a/resources/views/nav.blade.php
+++ b/resources/views/nav.blade.php
@@ -18,6 +18,11 @@
     <li class="nav-item">
       <a class="nav-link" href=""><i class="fas fa-search mr-1"></i>他の人の体験談を検索</a>
     </li>
+    @auth
+    <li class="nav-item">
+      <a class="nav-link" href="{{ route('conditions.create') }}"><i class="fas fa-search mr-1"></i>病名登録</a>
+    </li>
+    @endauth
 
     @auth
     <li class="nav-item dropdown">

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,9 +13,19 @@ use Illuminate\Http\Request;
 |
 */
 
+// ユーザー情報表示API
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
+// トークン更新API(必要な時に叩けばトークン情報が変わる)
 Route::get('/tokenupdate','ApiTokenController@update');
 
+
+// ログインユーザーのCondition情報取得API
+Route::middleware('auth:api')->group(function() {
+    Route::resource('conditions', 'ConditionController');
+});
+
+// 全ユーザーとCondition情報取得API
+Route::get('/allinfo', 'ConditionController@allinfo');

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,6 @@
 Auth::routes();
 
 Route::get('/', 'ConditionController@index');
-Route::resource('/conditions','ConditionController');
+Route::resource('/conditions','ConditionController')->middleware('auth');
 
 


### PR DESCRIPTION
■追加要素
・Conditiondataテーブル
・Condition情報の登録フォーム、Post機能（こちらConditiondataテーブルにいくつか病名を記入した上で開いてください。）
・ユーザー毎のCondition情報表示API（こちらはtoken認証必要）
・全てのユーザー＆Condition情報表示API（こちらはそのまま取得可）

■cloneして利用する場合の必要な設定
・migrate（1回目失敗したらrollbackして再度migrate）
・ssl化（AppServiceproviderのbootをコメント外す）